### PR TITLE
Multi RTA

### DIFF
--- a/MaceSetup_Configs/MultiRTA/SI.xml
+++ b/MaceSetup_Configs/MultiRTA/SI.xml
@@ -8,9 +8,19 @@
 	</Parameter>
    </Module>
 
+   <Module Class="RTA" Type="NASAPhase2">
+	<Parameter Name="ModuleParameters">
+		<Parameter Name="GlobalInstance">true</Parameter>
+	</Parameter>
+	<Parameter Name="EnvironmentParameters">
+		<Parameter Name="GridSpacing">1</Parameter>
+	</Parameter>
+   </Module>
+
 
 
   <Module Class="VehicleComms" Type="Ardupilot">
+    <Parameter Name="ID">2</Parameter>
     <Parameter Name="ProtocolParameters">
       <Parameter Name="Name">Mavlink</Parameter>
       <Parameter Name="Version">V2</Parameter>
@@ -27,10 +37,37 @@
   <Module Class="RTA" Type="NASAPhase2">
 	<Parameter Name="ModuleParameters">
 		<Parameter Name="GlobalInstance">false</Parameter>
+		<Parameter Name="SpecalizationID">2</Parameter>
 	</Parameter>
 	<Parameter Name="EnvironmentParameters">
 		<Parameter Name="GridSpacing">1</Parameter>
 	</Parameter>
    </Module>
+
+  <Module Class="VehicleComms" Type="Ardupilot">
+    <Parameter Name="ID">4</Parameter>
+    <Parameter Name="ProtocolParameters">
+      <Parameter Name="Name">Mavlink</Parameter>
+      <Parameter Name="Version">V2</Parameter>
+    </Parameter>
+        <Parameter Name="UDPParameters">
+      <Parameter Name="ListenAddress">192.168.1.20</Parameter>
+      <Parameter Name="ListenPortNumber">14550</Parameter>
+    </Parameter>
+    <Parameter Name="ModuleParameters">
+      <Parameter Name="AirborneInstance">false</Parameter>
+    </Parameter>
+  </Module>
+
+  <Module Class="RTA" Type="NASAPhase2">
+        <Parameter Name="ModuleParameters">
+                <Parameter Name="GlobalInstance">false</Parameter>
+                <Parameter Name="SpecalizationID">4</Parameter>
+        </Parameter>
+        <Parameter Name="EnvironmentParameters">
+                <Parameter Name="GridSpacing">1</Parameter>
+        </Parameter>
+   </Module>
+
    
 </ModuleConfigurations>

--- a/MaceSetup_Configs/MultiRTA/SI.xml
+++ b/MaceSetup_Configs/MultiRTA/SI.xml
@@ -1,0 +1,36 @@
+<ModuleConfigurations MaceInstance="1">
+
+  <Module Class="GroundStation" Type="NASAPhase2">
+	<Parameter Name="MACEComms">
+		<Parameter Name="GUIHostAddress">192.168.1.4</Parameter>
+		<Parameter Name="ListenPort">5678</Parameter>
+		<Parameter Name="SendPort">1234</Parameter>
+	</Parameter>
+   </Module>
+
+
+
+  <Module Class="VehicleComms" Type="Ardupilot">
+    <Parameter Name="ProtocolParameters">
+      <Parameter Name="Name">Mavlink</Parameter>
+      <Parameter Name="Version">V2</Parameter>
+    </Parameter>
+	<Parameter Name="UDPParameters">
+      <Parameter Name="ListenAddress">192.168.1.20</Parameter>
+      <Parameter Name="ListenPortNumber">14551</Parameter>
+    </Parameter>
+    <Parameter Name="ModuleParameters">
+      <Parameter Name="AirborneInstance">false</Parameter>
+    </Parameter>
+  </Module>
+  
+  <Module Class="RTA" Type="NASAPhase2">
+	<Parameter Name="ModuleParameters">
+		<Parameter Name="GlobalInstance">false</Parameter>
+	</Parameter>
+	<Parameter Name="EnvironmentParameters">
+		<Parameter Name="GridSpacing">1</Parameter>
+	</Parameter>
+   </Module>
+   
+</ModuleConfigurations>

--- a/src/common/publisher.h
+++ b/src/common/publisher.h
@@ -3,29 +3,47 @@
 
 #include <vector>
 #include <functional>
+#include "optional_parameter.h"
 
-template <typename Subscriber>
+template <typename Subscriber, typename Criteria = void*>
 class Publisher
 {
 public:
 
-    void AddSubscriber(Subscriber* ptr)
+    void AddSubscriber(Subscriber* ptr, OptionalParameter<Criteria> c = OptionalParameter<Criteria>())
     {
-        m_Subscribers.push_back(ptr);
+        m_Subscribers.push_back(std::make_tuple(ptr, c));
     }
 
 
     void Emit(const std::function<void(Subscriber *)> &func) const
     {
-        for(Subscriber *sub : m_Subscribers)
+        for(std::tuple<Subscriber*, OptionalParameter<Criteria>> sub : m_Subscribers)
         {
-            func(sub);
+            func(std::get<0>(sub));
+        }
+    }
+
+
+    void Emit(const std::function<void(Subscriber *)> &func, const Criteria &c) const
+    {
+        for(const std::tuple<Subscriber*, OptionalParameter<Criteria>> sub : m_Subscribers)
+        {
+            if(std::get<1>(sub).IsSet() == false)
+            {
+                throw std::runtime_error("A publisher has attempted to be emitted with criteria, yet no criteria exists for the subscriber");
+            }
+
+            if(std::get<1>(sub).Value() == c)
+            {
+                func(std::get<0>(sub));
+            }
         }
     }
 
 private:
 
-    std::vector<Subscriber*> m_Subscribers;
+    std::vector<std::tuple<Subscriber*, OptionalParameter<Criteria>>> m_Subscribers;
 };
 
 #endif // PUBLISHER_H

--- a/src/comms/comms_marshaler.cpp
+++ b/src/comms/comms_marshaler.cpp
@@ -22,7 +22,7 @@ CommsMarshaler::CommsMarshaler() :
 void CommsMarshaler::AddProtocol(const MavlinkConfiguration &config)
 {
     if(m_ProtocolObjects.find(Protocols::MAVLINK) != m_ProtocolObjects.cend())
-        throw std::runtime_error("Mavlink protocol has already been created");
+        return;
 
     std::shared_ptr<MavlinkProtocol> protocol = std::make_shared<MavlinkProtocol>(config);
     protocol->AddListner(this);
@@ -240,7 +240,8 @@ void CommsMarshaler::CommunicationError(const ILink* link_ptr, const std::string
     if(m_CreatedLinksPtrToName.find(link_ptr) == m_CreatedLinksPtrToName.cend())
         throw std::runtime_error("Provided link does not exists");
 
-    Emit([&](const CommsEvents *ptr){ptr->LinkCommunicationError(m_CreatedLinksPtrToName.at(link_ptr), type, msg);});
+    std::string linkName = m_CreatedLinksPtrToName.at(link_ptr);
+    Emit([&](const CommsEvents *ptr){ptr->LinkCommunicationError(linkName, type, msg);}, linkName);
 }
 
 void CommsMarshaler::CommunicationUpdate(const ILink* link_ptr, const std::string &name, const std::string &msg) const
@@ -248,7 +249,8 @@ void CommsMarshaler::CommunicationUpdate(const ILink* link_ptr, const std::strin
     if(m_CreatedLinksPtrToName.find(link_ptr) == m_CreatedLinksPtrToName.cend())
         throw std::runtime_error("Provided link does not exists");
 
-    Emit([&](const CommsEvents *ptr){ptr->LinkCommunicationUpdate(m_CreatedLinksPtrToName.at(link_ptr), name, msg);});
+    std::string linkName = m_CreatedLinksPtrToName.at(link_ptr);
+    Emit([&](const CommsEvents *ptr){ptr->LinkCommunicationUpdate(linkName, name, msg);}, linkName);
 }
 
 void CommsMarshaler::Connected(const ILink* link_ptr) const
@@ -256,7 +258,8 @@ void CommsMarshaler::Connected(const ILink* link_ptr) const
     if(m_CreatedLinksPtrToName.find(link_ptr) == m_CreatedLinksPtrToName.cend())
         throw std::runtime_error("Provided link does not exists");
 
-    Emit([&](const CommsEvents *ptr){ptr->LinkConnected(m_CreatedLinksPtrToName.at(link_ptr));});
+    std::string linkName = m_CreatedLinksPtrToName.at(link_ptr);
+    Emit([&](const CommsEvents *ptr){ptr->LinkConnected(linkName);}, linkName);
 }
 
 void CommsMarshaler::ConnectionRemoved(const ILink* link_ptr) const
@@ -264,7 +267,8 @@ void CommsMarshaler::ConnectionRemoved(const ILink* link_ptr) const
     if(m_CreatedLinksPtrToName.find(link_ptr) == m_CreatedLinksPtrToName.cend())
         throw std::runtime_error("Provided link does not exists");
 
-    Emit([&](const CommsEvents *ptr){ptr->LinkConnectionRemoved(m_CreatedLinksPtrToName.at(link_ptr));});
+    std::string linkName = m_CreatedLinksPtrToName.at(link_ptr);
+    Emit([&](const CommsEvents *ptr){ptr->LinkConnectionRemoved(linkName);}, linkName);
 }
 
 
@@ -285,7 +289,8 @@ void CommsMarshaler::ProtocolStatusMessage(const ILink* link_ptr, const std::str
     if(m_CreatedLinksPtrToName.find(link_ptr) == m_CreatedLinksPtrToName.cend())
         throw std::runtime_error("Provided link does not exists");
 
-    Emit([&](const CommsEvents *ptr){ptr->ProtocolStatusMessage(m_CreatedLinksPtrToName.at(link_ptr), title, message);});
+    std::string linkName = m_CreatedLinksPtrToName.at(link_ptr);
+    Emit([&](const CommsEvents *ptr){ptr->ProtocolStatusMessage(linkName, title, message);}, linkName);
 }
 
 
@@ -294,7 +299,8 @@ void CommsMarshaler::ReceiveLossPercentChanged(const ILink* link_ptr, int uasId,
     if(m_CreatedLinksPtrToName.find(link_ptr) == m_CreatedLinksPtrToName.cend())
         throw std::runtime_error("Provided link does not exists");
 
-    Emit([&](const CommsEvents *ptr){ptr->ReceiveLossPercentChanged(m_CreatedLinksPtrToName.at(link_ptr), uasId, lossPercent);});
+    std::string linkName = m_CreatedLinksPtrToName.at(link_ptr);
+    Emit([&](const CommsEvents *ptr){ptr->ReceiveLossPercentChanged(linkName, uasId, lossPercent);}, linkName);
 }
 
 void CommsMarshaler::ReceiveLossTotalChanged(const ILink* link_ptr, int uasId, int totalLoss) const
@@ -302,7 +308,8 @@ void CommsMarshaler::ReceiveLossTotalChanged(const ILink* link_ptr, int uasId, i
     if(m_CreatedLinksPtrToName.find(link_ptr) == m_CreatedLinksPtrToName.cend())
         throw std::runtime_error("Provided link does not exists");
 
-    Emit([&](const CommsEvents *ptr){ptr->ReceiveLossTotalChanged(m_CreatedLinksPtrToName.at(link_ptr), uasId, totalLoss);});
+    std::string linkName = m_CreatedLinksPtrToName.at(link_ptr);
+    Emit([&](const CommsEvents *ptr){ptr->ReceiveLossTotalChanged(linkName, uasId, totalLoss);}, linkName);
 }
 
 
@@ -323,7 +330,8 @@ void CommsMarshaler::MessageReceived(const ILink* link_ptr, const mavlink_messag
     if(m_CreatedLinksPtrToName.find(link_ptr) == m_CreatedLinksPtrToName.cend())
         throw std::runtime_error("Provided link does not exists");
 
-    Emit([&](CommsEvents *ptr){ptr->MavlinkMessage(m_CreatedLinksPtrToName.at(link_ptr), message);});
+    std::string linkName = m_CreatedLinksPtrToName.at(link_ptr);
+    Emit([&](CommsEvents *ptr){ptr->MavlinkMessage(linkName, message);}, linkName);
 }
 
 
@@ -340,7 +348,8 @@ void CommsMarshaler::VehicleHeartbeatInfo(const ILink* link_ptr, const int &syst
     if(m_CreatedLinksPtrToName.find(link_ptr) == m_CreatedLinksPtrToName.cend())
         throw std::runtime_error("Provided link does not exists");
 
-    Emit([&](CommsEvents *ptr){ptr->VehicleHeartbeatInfo(m_CreatedLinksPtrToName.at(link_ptr), systemID, heartbeatMSG);});
+    std::string linkName = m_CreatedLinksPtrToName.at(link_ptr);
+    Emit([&](CommsEvents *ptr){ptr->VehicleHeartbeatInfo(linkName, systemID, heartbeatMSG);}, linkName);
 }
 
 //!
@@ -359,7 +368,8 @@ void CommsMarshaler::RadioStatusChanged(const ILink* link_ptr, unsigned rxerrors
     if(m_CreatedLinksPtrToName.find(link_ptr) == m_CreatedLinksPtrToName.cend())
         throw std::runtime_error("Provided link does not exists");
 
-    Emit([&](const CommsEvents *ptr){ptr->RadioStatusChanged(m_CreatedLinksPtrToName.at(link_ptr), rxerrors, fixed, rssi, remrssi, txbuf, noise, remnoise);});
+    std::string linkName = m_CreatedLinksPtrToName.at(link_ptr);
+    Emit([&](const CommsEvents *ptr){ptr->RadioStatusChanged(linkName, rxerrors, fixed, rssi, remrssi, txbuf, noise, remnoise);}, linkName);
 }
 
 

--- a/src/comms/comms_marshaler.h
+++ b/src/comms/comms_marshaler.h
@@ -39,7 +39,7 @@ enum class Protocols
 //!
 //! When multiple links are using the same protol, they utilize protocol channels to differiciante themselves.
 //!
-class COMMSSHARED_EXPORT CommsMarshaler : public Publisher<CommsEvents>, private ILinkEvents, private IProtocolMavlinkEvents
+class COMMSSHARED_EXPORT CommsMarshaler : public Publisher<CommsEvents, std::string>, private ILinkEvents, private IProtocolMavlinkEvents
 {
 public:
 

--- a/src/commsMAVLINK/comms_mavlink.cpp
+++ b/src/commsMAVLINK/comms_mavlink.cpp
@@ -1,14 +1,16 @@
 #include "comms_mavlink.h"
 
+Comms::CommsMarshaler g_CommsMarshaler;
+
 CommsMAVLINK::CommsMAVLINK() :
-    m_LinkMarshaler(new Comms::CommsMarshaler), m_LinkName(""), m_LinkChan(0)
+    m_LinkName(""),
+    m_LinkChan(0)
 {
-    m_LinkMarshaler->AddSubscriber(this);
 }
 
 CommsMAVLINK::~CommsMAVLINK()
 {
-    delete m_LinkMarshaler;
+
 }
 
 uint8_t CommsMAVLINK::getLinkChannel() const
@@ -23,7 +25,7 @@ std::string CommsMAVLINK::getLinkName() const
 
 void CommsMAVLINK::TransmitMAVLINKMessage(const mavlink_message_t &msg)
 {
-    m_LinkMarshaler->SendMAVMessage(m_LinkName,msg);
+    g_CommsMarshaler.SendMAVMessage(m_LinkName,msg);
 }
 
 void CommsMAVLINK::VehicleHeartbeatInfo(const std::string &linkName, const int &systemID, const mavlink_heartbeat_t &heartbeatMSG)
@@ -99,7 +101,7 @@ void CommsMAVLINK::ConfigureComms(const std::shared_ptr<MaceCore::ModuleParamete
                 throw std::runtime_error("Unknown mavlink version seen");
             }
 
-            m_LinkMarshaler->AddProtocol(*mavlinkConfig);
+            g_CommsMarshaler.AddProtocol(*mavlinkConfig);
 
             m_AvailableProtocols.insert({Comms::Protocols::MAVLINK, std::static_pointer_cast<Comms::ProtocolConfiguration>(mavlinkConfig)});
             protocolConfig = mavlinkConfig;
@@ -137,19 +139,20 @@ void CommsMAVLINK::ConfigureComms(const std::shared_ptr<MaceCore::ModuleParamete
         config.setFlowControl(flowControl);
 
         m_LinkName = "link_" + portName;
-        m_LinkMarshaler->AddLink(m_LinkName, config);
+        g_CommsMarshaler.AddLink(m_LinkName, config);
+        g_CommsMarshaler.AddSubscriber(this, m_LinkName);
 
 
         //now configure to use link with desired protocol
         if(protocolToUse == Comms::Protocols::MAVLINK)
         {
-            m_LinkMarshaler->SetProtocolForLink(m_LinkName, Comms::Protocols::MAVLINK);
+            g_CommsMarshaler.SetProtocolForLink(m_LinkName, Comms::Protocols::MAVLINK);
 
             std::shared_ptr<Comms::MavlinkConfiguration> mavlinkConfig = std::static_pointer_cast<Comms::MavlinkConfiguration>(m_AvailableProtocols.at(Comms::Protocols::MAVLINK));
 
             //set version on mavlink channel
             // I would prefer to put this in Comms library, but because the mavlinkstatus is static variable, things get messed up when linking
-            m_LinkChan = m_LinkMarshaler->GetProtocolChannel(m_LinkName);
+            m_LinkChan = g_CommsMarshaler.GetProtocolChannel(m_LinkName);
             mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(m_LinkChan);
             std::cout << mavlinkStatus << std::endl;
             switch (mavlinkConfig->GetVersion()) {
@@ -170,7 +173,7 @@ void CommsMAVLINK::ConfigureComms(const std::shared_ptr<MaceCore::ModuleParamete
         }
 
 
-        if(m_LinkMarshaler->ConnectToLink(m_LinkName) == false){
+        if(g_CommsMarshaler.ConnectToLink(m_LinkName) == false){
             throw std::runtime_error("Connection to udp link failed");
         }
     }
@@ -191,18 +194,19 @@ void CommsMAVLINK::ConfigureComms(const std::shared_ptr<MaceCore::ModuleParamete
 //            config.listenForPort(listenPortNumber);
 
         m_LinkName = "udplink_" + std::to_string(listenPortNumber);
-        m_LinkMarshaler->AddUDPLink(m_LinkName, config);
+        g_CommsMarshaler.AddUDPLink(m_LinkName, config);
+        g_CommsMarshaler.AddSubscriber(this, m_LinkName);
 
         //now configure to use link with desired protocol
         if(protocolToUse == Comms::Protocols::MAVLINK)
         {
-            m_LinkMarshaler->SetProtocolForLink(m_LinkName, Comms::Protocols::MAVLINK);
+            g_CommsMarshaler.SetProtocolForLink(m_LinkName, Comms::Protocols::MAVLINK);
 
             std::shared_ptr<Comms::MavlinkConfiguration> mavlinkConfig = std::static_pointer_cast<Comms::MavlinkConfiguration>(m_AvailableProtocols.at(Comms::Protocols::MAVLINK));
 
             //set version on mavlink channel
             // I would prefer to put this in Comms library, but because the mavlinkstatus is static variable, things get messed up when linking
-            m_LinkChan = m_LinkMarshaler->GetProtocolChannel(m_LinkName);
+            m_LinkChan = g_CommsMarshaler.GetProtocolChannel(m_LinkName);
             mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(m_LinkChan);
             std::cout << mavlinkStatus << std::endl;
             switch (mavlinkConfig->GetVersion()) {
@@ -226,7 +230,7 @@ void CommsMAVLINK::ConfigureComms(const std::shared_ptr<MaceCore::ModuleParamete
         // ********************************************************************************************
 
         //connect link
-        if(m_LinkMarshaler->ConnectToLink(m_LinkName) == false){
+        if(g_CommsMarshaler.ConnectToLink(m_LinkName) == false){
             throw std::runtime_error("Connection to udp link failed");
         }
 
@@ -241,5 +245,5 @@ void CommsMAVLINK::ConfigureComms(const std::shared_ptr<MaceCore::ModuleParamete
 
 void CommsMAVLINK::Shutdown()
 {
-    m_LinkMarshaler->DisconnectFromLink(m_LinkName);
+    g_CommsMarshaler.DisconnectFromLink(m_LinkName);
 }

--- a/src/commsMAVLINK/comms_mavlink.h
+++ b/src/commsMAVLINK/comms_mavlink.h
@@ -20,6 +20,9 @@
 
 #include "mace_core/module_factory.h"
 
+//need a single global object to marshal from
+extern Comms::CommsMarshaler g_CommsMarshaler;
+
 class COMMSMAVLINKSHARED_EXPORT CommsMAVLINK :
         public Comms::CommsEvents
 {
@@ -46,7 +49,6 @@ public:
     std::string getLinkName() const;
 
 protected:
-    Comms::CommsMarshaler *m_LinkMarshaler;
     std::string m_LinkName;
     uint8_t m_LinkChan;
 

--- a/src/mace/configuration_reader_xml.cpp
+++ b/src/mace/configuration_reader_xml.cpp
@@ -141,8 +141,11 @@ static std::shared_ptr<MaceCore::ModuleParameterValue> ParseParameters(const pug
             else
             {
                 std::string defaultValue = structure->getDefaultTerminalValue(it->first);
-                result.warnings.push_back(nestedName + " not set, using default value of " + defaultValue);
-                valueContainer->AddTerminalValueFromString(it->first, defaultValue, structure->getTerminalType(it->first));
+                if(defaultValue != "")
+                {
+                    result.warnings.push_back(nestedName + " not set, using default value of " + defaultValue);
+                    valueContainer->AddTerminalValueFromString(it->first, defaultValue, structure->getTerminalType(it->first));
+                }
             }
         }
     }

--- a/src/mace_core/abstract_module_base.h
+++ b/src/mace_core/abstract_module_base.h
@@ -80,6 +80,11 @@ public:
 
 public:
 
+    ModuleBase() :
+        m_HasID(false)
+    {
+
+    }
 
     const static ModuleClasses moduleClass;
 
@@ -88,6 +93,18 @@ public:
     void SetID(int ID)
     {
         m_ID = ID;
+        m_HasID = true;
+    }
+
+    //!
+    //! \brief Determine if ID has ben set.
+    //!
+    //! Used at startup when some modules may have a "static" ID while others will be dynamically assinged
+    //! \return True if module has an ID assigned to it.
+    //!
+    bool HasID() const
+    {
+        return m_HasID;
     }
 
     int GetID() const
@@ -232,6 +249,7 @@ protected:
 private:
     std::shared_ptr<const MaceData> m_Data;
 
+    bool m_HasID;
     int m_ID;
 
     ///MTB MODULE AUTO ASSIGN

--- a/src/mace_core/abstract_module_base.h
+++ b/src/mace_core/abstract_module_base.h
@@ -81,7 +81,8 @@ public:
 public:
 
     ModuleBase() :
-        m_HasID(false)
+        m_HasID(false),
+        m_Started(false)
     {
 
     }
@@ -152,7 +153,7 @@ public:
     //!
     virtual void OnModulesStarted()
     {
-
+        m_Started = true;
     }
 
     //!
@@ -243,6 +244,19 @@ public:
     }
 
 protected:
+
+
+    //!
+    //! \brief ModuleStarted Determine if the MACE has indicated that the module is capable of running
+    //! \return True if MACE instance has indicated the module is good to go
+    //!
+    bool ModuleStarted() const
+    {
+        return m_Started;
+    }
+
+
+protected:
     std::string loggingPath;
     bool loggerCreated = false;
 
@@ -256,6 +270,11 @@ private:
     bool m_ParentMaceInstanceIDSet = false;
     uint32_t m_ParentMaceInstanceID;
     ///
+
+    //!
+    //! \brief Variable to indicate if the MACE instance is ready for this module to start it's processing
+    //!
+    bool m_Started;
 };
 
 

--- a/src/mace_core/mace_core.h
+++ b/src/mace_core/mace_core.h
@@ -118,11 +118,32 @@ public: //The following functions add specific modules to connect to mace core
     //!
     void AddROSModule(const std::shared_ptr<IModuleCommandROS> &ros);
 
+
+    //!
+    //! \brief Add a generic RTA module to the MACE instance
+    //!
+    //! This function simpy consults the module and calls either AddLocalModule_GlobalRTA or AddLocalModule_SpecializedRTA
+    //! \param rta Module to add
+    //!
+    void AddLocalModule_GenericRTA(const std::shared_ptr<IModuleCommandRTA> &rta);
+
+
     //!
     //! \brief AddRTAModule Add RTA module
     //! \param rta RTA module setup
     //!
-    void AddRTAModule(const std::shared_ptr<IModuleCommandRTA> &rta);
+    void AddLocalModule_GlobalRTA(const std::shared_ptr<IModuleCommandRTA> &rta);
+
+
+    //!
+    //! \brief Add a specialized RTA module
+    //!
+    //! A specialized RTA module coordianates with a specific resource (vehicle).
+    //! There may be multiple specalized RTA modules per MACE instance.
+    //! \param rta RTA module
+    //!
+    void AddLocalModule_SpecializedRTA(const std::shared_ptr<IModuleCommandRTA> &rta);
+
 
     //!
     //! \brief AddSensorsModule Add sensors module
@@ -707,6 +728,18 @@ public:
         return m_MaceInstanceID;
     }
 
+
+    //!
+    //! \brief Reserve Module IDs. This prevents the core from assigning this number
+    //!
+    //! Used in the case of statically assigned modules
+    //! \param IDs Vector of ID's to reserve, will replace current vector
+    //!
+    void setReservedIDs(const std::vector<int> &IDs)
+    {
+        m_ReservedModuleIDs = IDs;
+    }
+
 private:
     mutable std::mutex m_VehicleMutex;
 
@@ -726,12 +759,15 @@ private:
     std::shared_ptr<IModuleCommandPathPlanning> m_PathPlanning;
     std::shared_ptr<IModuleCommandROS> m_ROS;
     std::shared_ptr<IModuleCommandSensors> m_Sensors;
-    std::shared_ptr<IModuleCommandRTA> m_RTA;
+    std::shared_ptr<IModuleCommandRTA> m_GlobalRTA;
+    std::vector<std::shared_ptr<IModuleCommandRTA>> m_SpecailizedRTA;
 
     //! Map of modules and the local key to identiy them.
     std::unordered_map<uint32_t, std::shared_ptr<ModuleBase>> m_Modules;
     uint8_t m_MaceInstanceID;
     bool m_MaceInstanceIDSet;
+
+    std::vector<int> m_ReservedModuleIDs;
 
     std::shared_ptr<MaceData> m_DataFusion;
 };

--- a/src/mace_core/metadata_rta.h
+++ b/src/mace_core/metadata_rta.h
@@ -1,12 +1,65 @@
 #ifndef METADATA_RTA_H
 #define METADATA_RTA_H
 
+#include <memory>
+#include "abstract_module_base.h"
+
 namespace MaceCore
 {
 
 class Metadata_RTA
 {
+private:
 
+    bool m_IsGlobal;
+    int m_Specalization;
+
+public:
+
+    Metadata_RTA() :
+        m_IsGlobal(true),
+        m_Specalization(-1)
+    {
+
+    }
+
+    void SetGlobal()
+    {
+        m_IsGlobal = true;
+    }
+
+    void SetSpecalization(int moduleID)
+    {
+        m_IsGlobal = false;
+        m_Specalization = moduleID;
+    }
+
+
+    //!
+    //! \brief Determine if the RTA module is a global instance
+    //! \return True if global
+    //!
+    bool IsGlobal() const
+    {
+        return m_IsGlobal;
+    }
+
+
+    //!
+    //! \brief Determine what this RTA module is a specalization of.
+    //! \return Pointer to module this RTA is a specalization of. NULL if instance is global.
+    //!
+    int SpecalizationOf() const
+    {
+        if(m_IsGlobal)
+        {
+            throw std::runtime_error("Module is a global instance, It is not a specialization");
+        }
+        else
+        {
+            return m_Specalization;
+        }
+    }
 };
 
 } //End MaceCore Namespace

--- a/src/module_ROS/module_ROS.cpp
+++ b/src/module_ROS/module_ROS.cpp
@@ -92,7 +92,7 @@ std::shared_ptr<MaceCore::ModuleParameterStructure> ModuleROS::ModuleConfigurati
     cameraSensor->AddTerminalParameters("Type", MaceCore::ModuleParameterTerminalTypes::STRING, true, "rgb", {"rgb", "infrared"});
     structure.AddNonTerminal("CameraSensor", cameraSensor, true);
 
-    //    structure.AddTerminalParameters("ID", MaceCore::ModuleParameterTerminalTypes::INT, true);
+    structure.AddTerminalParameters("ID", MaceCore::ModuleParameterTerminalTypes::INT, false);
 
     return std::make_shared<MaceCore::ModuleParameterStructure>(structure);
 }
@@ -126,7 +126,10 @@ void ModuleROS::ConfigureModule(const std::shared_ptr<MaceCore::ModuleParameterV
         m_sensors.push_back(sensor);
     }
 
-    //    this->SetID(params->GetTerminalValue<int>("ID"));
+    if(params->HasTerminal("ID"))
+    {
+        this->SetID(params->GetTerminalValue<int>("ID"));
+    }
 }
 
 //!

--- a/src/module_ground_station/module_ground_station.cpp
+++ b/src/module_ground_station/module_ground_station.cpp
@@ -243,7 +243,7 @@ std::shared_ptr<MaceCore::ModuleParameterStructure> ModuleGroundStation::ModuleC
     maceCommsParams->AddTerminalParameters("ListenPort", MaceCore::ModuleParameterTerminalTypes::INT, false);
     maceCommsParams->AddTerminalParameters("SendPort", MaceCore::ModuleParameterTerminalTypes::INT, false);
     structure.AddNonTerminal("MACEComms", maceCommsParams, false);
-    structure.AddTerminalParameters("ID", MaceCore::ModuleParameterTerminalTypes::INT, true);
+    structure.AddTerminalParameters("ID", MaceCore::ModuleParameterTerminalTypes::INT, false);
 
     return std::make_shared<MaceCore::ModuleParameterStructure>(structure);
 }
@@ -272,7 +272,10 @@ void ModuleGroundStation::ConfigureModule(const std::shared_ptr<MaceCore::Module
         }
     }
 
-    this->SetID(params->GetTerminalValue<int>("ID"));
+    if(params->HasTerminal("ID"))
+    {
+        this->SetID(params->GetTerminalValue<int>("ID"));
+    }
 
     m_guiHostAddress = guiHostAddress;
     m_listenPort = listenPort;

--- a/src/module_path_planning_NASAPhase2/module_path_planning_nasaphase2.cpp
+++ b/src/module_path_planning_NASAPhase2/module_path_planning_nasaphase2.cpp
@@ -100,6 +100,8 @@ std::shared_ptr<MaceCore::ModuleParameterStructure> ModulePathPlanningNASAPhase2
 
 void ModulePathPlanningNASAPhase2::OnModulesStarted()
 {
+    MaceCore::ModuleBase::OnModulesStarted();
+
     std::cout<<"All of the modules have been started."<<std::endl;
     ModulePathPlanningNASAPhase2::NotifyListeners([&](MaceCore::IModuleEventsPathPlanning* ptr) {
         ptr->Event_SetGlobalOrigin(this, m_globalOrigin);

--- a/src/module_resource_task_allocation/module_rta.cpp
+++ b/src/module_resource_task_allocation/module_rta.cpp
@@ -39,13 +39,14 @@ std::shared_ptr<MaceCore::ModuleParameterStructure> ModuleRTA::ModuleConfigurati
 
     std::shared_ptr<MaceCore::ModuleParameterStructure> moduleSettings = std::make_shared<MaceCore::ModuleParameterStructure>();
     moduleSettings->AddTerminalParameters("GlobalInstance", MaceCore::ModuleParameterTerminalTypes::BOOLEAN, true);
+    moduleSettings->AddTerminalParameters("SpecalizationID", MaceCore::ModuleParameterTerminalTypes::INT, false);
     structure.AddNonTerminal("ModuleParameters", moduleSettings, true);
 
     std::shared_ptr<MaceCore::ModuleParameterStructure> environmentParams = std::make_shared<MaceCore::ModuleParameterStructure>();
     environmentParams->AddTerminalParameters("GridSpacing", MaceCore::ModuleParameterTerminalTypes::DOUBLE, true);
     structure.AddNonTerminal("EnvironmentParameters", environmentParams, true);
 
-    structure.AddTerminalParameters("ID", MaceCore::ModuleParameterTerminalTypes::INT, true);
+    structure.AddTerminalParameters("ID", MaceCore::ModuleParameterTerminalTypes::INT, false);
 
     return std::make_shared<MaceCore::ModuleParameterStructure>(structure);
 }
@@ -57,13 +58,32 @@ std::shared_ptr<MaceCore::ModuleParameterStructure> ModuleRTA::ModuleConfigurati
 //!
 void ModuleRTA::ConfigureModule(const std::shared_ptr<MaceCore::ModuleParameterValue> &params)
 {
+    MaceCore::Metadata_RTA meta;
 
-    this->SetID(params->GetTerminalValue<int>("ID"));
+    if(params->HasTerminal("ID"))
+    {
+        this->SetID(params->GetTerminalValue<int>("ID"));
+    }
 
     if(params->HasNonTerminal("ModuleParameters"))
     {
         std::shared_ptr<MaceCore::ModuleParameterValue> moduleSettings = params->GetNonTerminalValue("ModuleParameters");
         m_globalInstance = moduleSettings->GetTerminalValue<bool>("GlobalInstance");
+
+        if(m_globalInstance == true)
+        {
+            meta.SetGlobal();
+        }
+        else
+        {
+            if(moduleSettings->HasTerminal("SpecalizationID") == false)
+            {
+                throw std::runtime_error ("RTA module has been marked as not-global, yet no SpecalizationID parameter given");
+            }
+            int specalizationID = moduleSettings->GetTerminalValue<int>("SpecalizationID");
+            meta.SetSpecalization(specalizationID);
+        }
+
     }
 
     if(params->HasNonTerminal("EnvironmentParameters")) {
@@ -79,6 +99,7 @@ void ModuleRTA::ConfigureModule(const std::shared_ptr<MaceCore::ModuleParameterV
         throw std::runtime_error("Unkown RTA parameters encountered");
     }
 
+    this->setModuleMetaData(meta);
 }
 
 
@@ -238,13 +259,41 @@ void ModuleRTA::NewlyUpdatedGlobalOrigin(const mace::pose::GeodeticPosition_3D &
 //!
 void ModuleRTA::NewlyAvailableBoundary(const uint8_t &key, const OptionalParameter<MaceCore::ModuleCharacteristic> &sender)
 {
+    BoundaryItem::BoundaryCharacterisic characterstic;
     BoundaryItem::BoundaryList boundary;
     this->getDataObject()->getBoundaryFromIdentifier(key, boundary);
+    this->getDataObject()->getCharactersticFromIdentifier(key, characterstic);
 
-    updateEnvironment(boundary);
+    /// If its not global and is a resource fence
+    ///   Check if we care about module and do further processing
+    if(this->getModuleMetaData().IsGlobal() == false && characterstic.Type() == BoundaryItem::BOUNDARYTYPE::RESOURCE_FENCE)
+    {
+        // Determine the module which this RTA module is a specalization of
+        MaceCore::ModuleCharacteristic specalizedModule;
+        specalizedModule.MaceInstance = this->getParentMaceInstanceID();
+        specalizedModule.ModuleID = this->getModuleMetaData().SpecalizationOf();
 
-    if(m_globalInstance) {
-        // If global, loop over all vehicles and send their ResourceFence
+        // Determine the vehicleID this RTA module is a specalization of
+        int vehicleID = this->getDataObject()->getMavlinkIDFromModule(specalizedModule);
+
+        // Determine the module that the given boundary is assositated with
+        if(characterstic.ContainsVehicle(vehicleID) == false) return;
+
+        printf("RTA Module for Vehicle %d received a new Rsource Fence\n", vehicleID);
+
+        // /////////////////////////////
+        // PROCESS BOUNDARY
+        // /////////////////////////////
+    }
+
+
+    /// If this module is a global instance and the boundary is an operational fence:
+    ///   Then partition out and give new resource boundaries to Core.
+    if(this->getModuleMetaData().IsGlobal() == true && characterstic.Type() == BoundaryItem::BOUNDARYTYPE::OPERATIONAL_FENCE) {
+
+        //MTB - According to Pat, this method only makes sense to call on global RTA module that is partioning a OP-fence to resource-fence
+        updateEnvironment(boundary);
+
         for(auto vehicleCell : m_vehicleCells) {
             int vehicleID = vehicleCell.first;
             BoundaryItem::BoundaryList resourceFence;

--- a/src/module_resource_task_allocation/module_rta.h
+++ b/src/module_resource_task_allocation/module_rta.h
@@ -73,6 +73,8 @@ public:
     //!
     virtual void NewTopicSpooled(const std::string &topicName, const MaceCore::ModuleCharacteristic &sender, const std::vector<std::string> &componentsUpdated, const OptionalParameter<MaceCore::ModuleCharacteristic> &target = OptionalParameter<MaceCore::ModuleCharacteristic>());
 
+public:
+
 
     // ============================================================================= //
     // ======== Virtual functions as defined by IModuleCommandGenericBoundaries ==== //

--- a/src/module_vehicle_MAVLINK/module_vehicle_mavlink.h
+++ b/src/module_vehicle_MAVLINK/module_vehicle_mavlink.h
@@ -98,6 +98,7 @@ public:
         std::shared_ptr<MaceCore::ModuleParameterStructure> moduleSettings = std::make_shared<MaceCore::ModuleParameterStructure>();
         moduleSettings->AddTerminalParameters("AirborneInstance", MaceCore::ModuleParameterTerminalTypes::BOOLEAN, true);
         structure.AddNonTerminal("ModuleParameters", moduleSettings, true);
+        structure.AddTerminalParameters("ID", MaceCore::ModuleParameterTerminalTypes::INT, false);
 
         return std::make_shared<MaceCore::ModuleParameterStructure>(structure);
     }
@@ -114,6 +115,11 @@ public:
         {
             std::shared_ptr<MaceCore::ModuleParameterValue> moduleSettings = params->GetNonTerminalValue("ModuleParameters");
             airborneInstance = moduleSettings->GetTerminalValue<bool>("AirborneInstance");
+        }
+
+        if(params->HasTerminal("ID"))
+        {
+            this->SetID(params->GetTerminalValue<int>("ID"));
         }
     }
 

--- a/src/module_vehicle_ardupilot/module_vehicle_ardupilot.cpp
+++ b/src/module_vehicle_ardupilot/module_vehicle_ardupilot.cpp
@@ -478,6 +478,12 @@ bool ModuleVehicleArdupilot::MavlinkMessage(const std::string &linkName, const m
 //!
 void ModuleVehicleArdupilot::VehicleHeartbeatInfo(const std::string &linkName, const int &systemID, const mavlink_heartbeat_t &heartbeatMSG)
 {
+    //If module hasn't started yet, then ignore this message
+    if(this->ModuleStarted() == false)
+    {
+        return;
+    }
+
     UNUSED(linkName);
     if(vehicleData == nullptr)
     {


### PR DESCRIPTION
See: https://trello.com/c/KKMx6OGs

ID is now not required in MaceSetup Config schema. However it is needed for a VehicleComms object should you want to tie an RTA module to that vehicle.